### PR TITLE
client/python: add protobuf dependency

### DIFF
--- a/client/python/requirements.txt
+++ b/client/python/requirements.txt
@@ -1,1 +1,2 @@
 grpcio
+protobuf

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -8,5 +8,6 @@ setup(
     install_requires=[
         'grpcio',
         'PyQt5',
+        'protobuf',
     ],
 )


### PR DESCRIPTION
grpc/grpc#15034: since grpcio 1.12.0, it does not depend on the protobuf package.
We should list it.